### PR TITLE
[quesBank] update: QuestionApi

### DIFF
--- a/cmd/api-server/QuestionApi.go
+++ b/cmd/api-server/QuestionApi.go
@@ -48,16 +48,28 @@ func (LocalQuestionApi) SelectsTypeApi(c *gin.Context) {
 	return
 }
 
+type QuestionRequest struct {
+	Type    qtype.QType        `json:"type"`
+	Content string             `json:"content"`
+	Options entity.StringArray `json:"options"`
+}
+
 // 题目请求Api
 func QuestionApi(c *gin.Context) {
-	var question entity.Question
+	var question QuestionRequest
 
 	if err := c.ShouldBindJSON(&question); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 	}
 
 	//查询题目
-	result := ques_core.AutoResearch(question)
+	result := ques_core.AutoResearch(entity.Question{
+		Md5:     "",
+		Type:    question.Type,
+		Content: question.Content,
+		Options: question.Options,
+		Answers: nil,
+	})
 	if result != nil {
 		c.JSON(http.StatusOK, entity.ResultQuestion{
 			Question: result.Question,


### PR DESCRIPTION
### 修改最原始的`questionApi`
此处的请求方式应该为Core或别处请求时候只知道的type与content 并无 md5 answer等不可知字段
```go
type QuestionRequest struct {
	Type    qtype.QType        `json:"type"`
	Content string             `json:"content"`
	Options entity.StringArray `json:"options"`
}

//查询题目
	result := ques_core.AutoResearch(entity.Question{
		Md5:     "",
		Type:    question.Type,
		Content: question.Content,
		Options: question.Options,
		Answers: nil,
	})
```