### PR TITLE
CI: 修复CI编译问题，启用 cgo 支持 SQLite 编译

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,8 @@ jobs:
       # Build Linux AMD64
       - name: Build Linux AMD64
         run: |
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+          sudo apt-get install -y libsqlite3-dev
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
             -o ${{ env.RELEASE_DIR }}/yatori-go-quesbank.${{env.VERSION}}-linux-amd64-release/${{ env.PROJECT_NAME }}
       - name: Create release tar
         run: | # 打包发布版本压缩包


### PR DESCRIPTION
禁用 CGO 编译
在 Linux 上会存在问题
```
2025/11/03 11:05:17 /home/runner/work/yatori-go-quesbank/yatori-go-quesbank/cmd/BankInit.go:49
[error] failed to initialize database, got error Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
panic: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub

goroutine 1 [running]:
yatori-go-quesbank/cmd.DBInit({0xc00049e6b0, 0xf})
        /home/runner/work/yatori-go-quesbank/yatori-go-quesbank/cmd/BankInit.go:51 +0x214
yatori-go-quesbank/cmd.BankInit()
        /home/runner/work/yatori-go-quesbank/yatori-go-quesbank/cmd/BankInit.go:25 +0xce
main.main()
        /home/runner/work/yatori-go-quesbank/yatori-go-quesbank/main.go:8 +0xf
```

